### PR TITLE
Update index.md - 'developer distance is reduced to it's minimum', not 'to it's max'

### DIFF
--- a/content/5-min-overview/index.md
+++ b/content/5-min-overview/index.md
@@ -22,7 +22,7 @@ that might:
 * not show that work was duplicated until it is merged
 * not show problems of incompatibility/undesirability that does not break the build
 
-Trunk-Based Development is a branching model that reduces the distance to the max. 
+Trunk-Based Development is a branching model that reduces the distance to the minimum. 
  
 ## What it is
 


### PR DESCRIPTION
Hello, 

I think when a quantity of something is reduced its value decreases. The greatest available reduction in a quantity results in that quantity ending at its minimum value, not its maximum value.  

Therefore the developer distance is being reduced to it's minimum, not reduced to its maximum.