### PR TITLE
Mentioned new Pipeline DSL capability in Jenkins

### DIFF
--- a/content/continuous-integration/index.md
+++ b/content/continuous-integration/index.md
@@ -212,7 +212,7 @@ branch too.
 * JetBrains' TeamCity{{< ext url="https://www.jetbrains.com/teamcity" >}} - on-premises install
 * Microsoft's TFS platform{{< ext url="https://www.visualstudio.com/tfs" >}} - on-premises install (built into larger platform)
 
-Note, for Jenkins, you should use it with GroupOn's DotCI{{< ext url="https://github.com/groupon/DotCi" >}} to co-locate the config 
+Note, for Jenkins, you can now use Pipeline DSL scripts (or Groovy) {{< ext url="https://jenkins.io/doc/book/pipeline/" > }} (formerly Workflow), or you can use Jenkins with GroupOn's DotCI{{< ext url="https://github.com/groupon/DotCi" >}} to co-locate the config 
 with the thing being built/verified in source-control.
 
 # References elsewhere


### PR DESCRIPTION
I'm using Pipeline DSL scripts for 20 Java projects now and each one has a Jenkinsfile script that is maintained right next to the build.gradle file in their repos.