### PR TITLE
Remove redundant "are" in monorepos page

### DIFF
--- a/content/monorepos/index.md
+++ b/content/monorepos/index.md
@@ -122,7 +122,7 @@ them from your IDE.
 Google has Blaze internally. Ex-Googlers at Facebook (with newfound friends) missed that, wrote
 Buck{{< ext url="https://buckbuild.com" >}} and then
 open-sourced it. Google then open-sourced a cut-down Blaze as Bazel{{< ext url="https://bazel.build" >}}.
-These are the two (three including Blaze) are directed graph build systems that allow a large tree of sources to be speedily
+These are the two (three including Blaze) directed graph build systems that allow a large tree of sources to be speedily
 subset in a compile/test/make-a-binary way.
 
 The omitting of unnecessary compile/test actions achieved by Buck and Bazel works equally well on developer workstations


### PR DESCRIPTION
Thanks so much for the awesome document on monorepos! It helped me a lot.

The following sentence is syntactically wrong:

"These are the two (three including Blaze) are directed graph build systems..."

It was probably meant to be one of the following:

- "These are the two (three including Blaze) directed graph build systems..."
- "These two (three including Blaze) are directed graph build systems..."

I took a chance and chose the first one :-)