### PR TITLE
Noted explicitly that release branches are NOT merged back to the trunk

### DIFF
--- a/content/branch-for-release/index.md
+++ b/content/branch-for-release/index.md
@@ -120,9 +120,9 @@ is retroactively created from that tag, and the patch release (see above) can ha
 
 ## Release branch deletion
 
-Release branches are deleted some time after release activity from them ceases. Not immediately, but when it is clear release is no longer in production.
+Release branches are deleted some time after release activity from them ceases. Not immediately, but when it is clear release is no longer in production. Release branches are NOT merged back into trunk.
 That is usually when releases from succeeding release branches have gone live. This is a
-harmless tidying activity - branches can be undeleted again easily enough in all VCS choices.
+harmless tidying activity - branches can be undeleted again easily enough in all VCS choices. In git, a tag needs to be created from the released commit before deleting the release branch, since dangling commits will be garbage collected.
 
 # References elsewhere
 


### PR DESCRIPTION
In several locations, the website says that branches are deleted, but does not explicitly state whether the branch is merged back to trunk or not. This is confusing, therefore I‘d suggest to explicitly state it. 