### PR TITLE
Removed printable version from book page

### DIFF
--- a/content/book/index.md
+++ b/content/book/index.md
@@ -7,7 +7,6 @@ weight: 132
 The TrunkBasedDevelopment.com site transformed into book, via scripts:
 
 * [English PDF](https://book.trunkbaseddevelopment.com/trunk_based_development_book.pdf) - interactive 
-* [English PDF](https://book.trunkbaseddevelopment.com/trunk_based_development_book_printable.pdf) - printable with all links changed to footnotes (noninteractive) 
 * [English MOBI](https://book.trunkbaseddevelopment.com/trunk_based_development_book.mobi) - for Amazon's Kindle
 * [English EPUB](https://book.trunkbaseddevelopment.com/trunk_based_development_book.epub) - for iBooks, Google Books, Nook, and others
 


### PR DESCRIPTION
I removed the printable with all links changed to footnotes from the list of downloadable books. Not that it's not useful but the current link is broken, it redirects to the interactive version of the PDF.

I couldn't find the scripts that generate and save the PDF versions so all I could do was to remove the link.

However a better solution would be to update the PDF at https://book.trunkbaseddevelopment.com/trunk_based_development_book_printable.pdf 

I apologize if I could have done it myself and missed it