### PR TITLE
fix: compatibility with newer Hugo version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -194,3 +194,9 @@ googleAnalytics = "UA-24415524-3"
   changefreq = "weekly"
   priority = 0.5
   filename = "sitemap.xml"
+
+[security.funcs]
+  getenv = ['COMMIT_REF']
+
+[markup.goldmark.renderer]
+  unsafe = true # Allow HTML in md files

--- a/themes/hugo-material-docs/layouts/_default/single.html
+++ b/themes/hugo-material-docs/layouts/_default/single.html
@@ -24,7 +24,7 @@
 
 	<article class="article">
 		<div class="wrapper">
-			<h1 style="color: white; padding: 32px 20px 72px; background-image:url(/images/LogoSlim.png); background-repeat: no-repeat; background-size: 100% auto"><span style="background-color: #5677fc">{{ .Title }} {{ if .IsDraft }} (Draft){{ end }}</span></h1>
+			<h1 style="color: white; padding: 32px 20px 72px; background-image:url(/images/LogoSlim.png); background-repeat: no-repeat; background-size: 100% auto"><span style="background-color: #5677fc">{{ .Title }} {{ if .Draft }} (Draft){{ end }}</span></h1>
 
 			{{ .Content }}
 

--- a/themes/hugo-material-docs/layouts/index.html
+++ b/themes/hugo-material-docs/layouts/index.html
@@ -25,7 +25,7 @@
 	<article class="article">
 		<div class="wrapper">
 			{{ range where .Site.Pages "Type" "index" }}
-				<h1>{{ .Title }} {{ if .IsDraft }} (Draft){{ end }}</h1>
+				<h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 				{{ .Content }}
 			{{ end }}

--- a/themes/hugo-material-docs/layouts/partials/head.html
+++ b/themes/hugo-material-docs/layouts/partials/head.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>{{ .Title }}{{ if not .IsHome }} - {{ .Site.Title }}{{ end }}</title>
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
 
     {{ with .Site.Params.description }}
     <meta name="description" content="{{ . }}">
@@ -70,7 +70,7 @@
     {{ end }}
     <script src="{{ "javascripts/modernizr.js" | absURL }}"></script>
 
-    {{ with .RSSLink }}
+    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}
     <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
     <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
     {{ end }}


### PR DESCRIPTION
Hi, first of all thanks for the amazing site :D 

While traversing I've found some seemingly broken sections of the page, e.g.
- https://trunkbaseddevelopment.com/publications/
- some embedded videos in https://trunkbaseddevelopment.com/game-changers/

After tinkering around in local with a newer Hugo version (`v0.119.0`), I found that Hugo changed their markdown parse to https://github.com/yuin/goldmark, where they

> By default, goldmark does not render raw HTML or potentially dangerous links. With this option, goldmark renders such content as written.

Assuming that the ones hosted on Netlify uses a version that changed Hugo's default parser to `goldmark`, this PR toggles the `unsafe` config to `true` to allow raw HTML in markdown.

In addition to that I had to fix the theme in accordance to the newer template API.