### PR TITLE
Remove reference to Bors-NG as it is deprecated in favor in github merge queue

### DIFF
--- a/content/deciding-factors/index.md
+++ b/content/deciding-factors/index.md
@@ -79,7 +79,7 @@ this way without encountering the same problem. This is known as the "race to pu
 Fork-based "pull requests" and similar branch-based "merge requests" in hosted git services solve this to a degree, with robots 
 keeping pull-request branches abreast of `origin:main` automatically as long as no conflicts arise.
 
-If you are using Github as your repository host, there is a tool that can help solve the "race to push" problem. It is called Bors-NG{{< ext url="https://github.com/bors-ng/bors-ng" >}} and it is a merge bot for GitHub pull requests. It will take care of merging the latest trunk version into your branch, running all needed tests and merging the result back into the trunk, managing this as a queue and removing these race conditions.
+If you are using Github as your repository host, [Github Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) can help solve the "race to push" problem. This will automate pull request merges into a busy branch to increase velocity.
 
 Even with Pull Requests, however, very high commit frequencies to the shared repo means contention and an artificial 
 serialization. Microsoft acknowledged this as one


### PR DESCRIPTION
Bors-NG was recently deprecated in favor of Github merge queue (see https://bors.tech/newsletter/2023/04/30/tmib-76/ )
This updates the reference to point to Github Merge Queue instead.
